### PR TITLE
change base image to python-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
-FROM ubuntu:latest
+FROM python:3-alpine
 
 RUN mkdir -p /usr/src/jaram-gaming-welcomebot
 WORKDIR /usr/src/jaram-gaming-welcomebot
-RUN apt-get update && apt-get install -y 
-RUN apt-get install -y python3-pip
+
 
 COPY . .
 RUN pip3 install --no-cache-dir -r ./requirements.txt


### PR DESCRIPTION
Change base docker image from ubuntu:latest to python:3-alpine.
It doesn't need `apt-get` process anymore